### PR TITLE
Add built-in PlaceholderAPI expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ top-10 format or individually. Currently tested on all versions between **1.16.5
 
 
 * **PlaceholderAPI support**
-   - Placeholders are added in a separate expansion, which can be found on [GitHub](https://github.com/Artemis-the-gr8/PlayerStatsExpansion), in the PlaceholderAPI [eCloud](https://api.extendedclip.com/expansions/playerstatsexpansion/), or downloaded in-game with `/papi ecloud download PlayerStats`
-   - For more information about the placeholders, see the expansion's [GitHub](https://github.com/Artemis-the-gr8/PlayerStatsExpansion)!
+   - PlayerStats now ships with a built-in PlaceholderAPI expansion. Install PlaceholderAPI, reload, and the placeholders are registered automatically.
+   - Use placeholders with the syntax `%playerstats_<target>|<statistic>[|<sub-statistic>][|option=value][|flag]%` where `<target>` can be `player`, `server`, or `top`.
+   - Examples:
+     - `%playerstats_player|JUMP|player=Notch%` – total jumps for Notch.
+     - `%playerstats_server|MOB_KILLS|formatted%` – formatted server-wide mob kills.
+     - `%playerstats_top|MINE_BLOCK|diamond_ore|position=1|formatted%` – formatted top entry for diamond ore mining.
 
 
 * **Safe**

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/Main.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/Main.java
@@ -11,13 +11,12 @@ import com.artemis.the.gr8.playerstats.core.msg.OutputManager;
 import com.artemis.the.gr8.playerstats.core.msg.msgutils.LanguageKeyHandler;
 import com.artemis.the.gr8.playerstats.core.msg.msgutils.NumberFormatter;
 import com.artemis.the.gr8.playerstats.core.multithreading.ThreadManager;
+import com.artemis.the.gr8.playerstats.core.placeholder.PlayerStatsPlaceholderExpansion;
 import com.artemis.the.gr8.playerstats.core.sharing.ShareManager;
 import com.artemis.the.gr8.playerstats.core.statistic.StatRequestManager;
 import com.artemis.the.gr8.playerstats.core.storage.WorldStatsDatabase;
 import com.artemis.the.gr8.playerstats.core.storage.WorldStatsSynchronizer;
 import com.artemis.the.gr8.playerstats.core.utils.*;
-import me.clip.placeholderapi.PlaceholderAPIPlugin;
-import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.Bukkit;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -44,6 +43,9 @@ public final class Main extends JavaPlugin implements PlayerStats {
 
     private static List<Reloadable> reloadables;
     private static List<Closable> closables;
+
+    private PlayerStatsPlaceholderExpansion placeholderExpansion;
+    private boolean placeholderApiActive;
 
     @Override
     public void onEnable() {
@@ -79,6 +81,7 @@ public final class Main extends JavaPlugin implements PlayerStats {
 
         initializeMainClassesInOrder();
         registerCommands();
+        registerPlaceholderExpansion();
         setupMetrics();
 
         // rejestrujemy listener
@@ -96,6 +99,12 @@ public final class Main extends JavaPlugin implements PlayerStats {
         } catch (Exception e) {
             getLogger().warning("Nie udało się zapisać world_stats.json: " + e.getMessage());
         }
+
+        if (placeholderExpansion != null) {
+            placeholderExpansion.unregister();
+            placeholderExpansion = null;
+        }
+        placeholderApiActive = false;
 
         closables.forEach(Closable::close);
         getLogger().info("Disabled PlayerStats!");
@@ -166,20 +175,26 @@ public final class Main extends JavaPlugin implements PlayerStats {
         }
     }
 
+    private void registerPlaceholderExpansion() {
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            placeholderExpansion = new PlayerStatsPlaceholderExpansion(this);
+            placeholderApiActive = placeholderExpansion.register();
+            if (placeholderApiActive) {
+                getLogger().info("Registered PlayerStats placeholders with PlaceholderAPI");
+            } else {
+                getLogger().warning("Failed to register PlayerStats placeholders with PlaceholderAPI");
+                placeholderExpansion = null;
+            }
+        } else {
+            placeholderApiActive = false;
+            placeholderExpansion = null;
+        }
+    }
+
     private void setupMetrics() {
         final Metrics metrics = new Metrics(pluginInstance, 15923);
-        final boolean placeholderExpansionActive;
-        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
-            PlaceholderExpansion expansion = PlaceholderAPIPlugin
-                    .getInstance()
-                    .getLocalExpansionManager()
-                    .getExpansion("playerstats");
-            placeholderExpansionActive = expansion != null;
-        } else {
-            placeholderExpansionActive = false;
-        }
         metrics.addCustomChart(new Metrics.SimplePie("using_placeholder_expansion",
-                () -> placeholderExpansionActive ? "yes" : "no"));
+                () -> placeholderApiActive ? "yes" : "no"));
 
         CommandCounter counter = CommandCounter.getInstance();
         metrics.addCustomChart(new Metrics.AdvancedPie("commands_used_the_last_30_minutes",

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/placeholder/PlayerStatsPlaceholderExpansion.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/placeholder/PlayerStatsPlaceholderExpansion.java
@@ -1,0 +1,387 @@
+package com.artemis.the.gr8.playerstats.core.placeholder;
+
+import com.artemis.the.gr8.playerstats.api.RequestGenerator;
+import com.artemis.the.gr8.playerstats.api.StatRequest;
+import com.artemis.the.gr8.playerstats.api.StatResult;
+import com.artemis.the.gr8.playerstats.core.Main;
+import com.artemis.the.gr8.playerstats.core.config.ConfigHandler;
+import com.artemis.the.gr8.playerstats.core.statistic.PlayerStatRequest;
+import com.artemis.the.gr8.playerstats.core.statistic.ServerStatRequest;
+import com.artemis.the.gr8.playerstats.core.statistic.StatRequestManager;
+import com.artemis.the.gr8.playerstats.core.statistic.TopStatRequest;
+import com.artemis.the.gr8.playerstats.core.utils.EnumHandler;
+import com.artemis.the.gr8.playerstats.core.utils.OfflinePlayerHandler;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.Material;
+import org.bukkit.Statistic;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+/**
+ * PlaceholderAPI expansion that exposes PlayerStats lookups directly from the plugin.
+ * <p>
+ * The supported placeholder format is structured as follows:
+ * <pre>
+ *   %playerstats_{target}|{statistic}[|{sub-statistic}][|option=value][|flag]...%
+ * </pre>
+ * Target can be {@code player}, {@code server} or {@code top}. Options control the
+ * lookup and output. Supported options and flags:
+ * <ul>
+ *   <li>{@code player=<name>} – overrides the player that is looked up. When omitted
+ *   for player lookups, the player that triggers the placeholder is used.</li>
+ *   <li>{@code world=<world>} – limits the lookup to the specified world (requires
+ *   statistics to be synced per-world).</li>
+ *   <li>{@code size=<number>} – size of the top list (only for {@code top}).</li>
+ *   <li>{@code position=<number>} – 1-based position to return from the top list.</li>
+ *   <li>{@code formatted} – returns the formatted message (similar to /stat output).</li>
+ *   <li>{@code value} – return only the numerical value (for {@code top} placeholders,
+ *   this applies to the selected entry).</li>
+ *   <li>{@code rank} – when used together with {@code player=<name>} on {@code top}
+ *   placeholders, returns the ranking position instead of the value.</li>
+ * </ul>
+ */
+public final class PlayerStatsPlaceholderExpansion extends PlaceholderExpansion {
+
+    private static final Pattern OPTION_SPLIT_PATTERN = Pattern.compile("\\|");
+
+    private final Main plugin;
+    private final EnumHandler enumHandler;
+    private final ConfigHandler config;
+    private final OfflinePlayerHandler offlinePlayerHandler;
+
+    public PlayerStatsPlaceholderExpansion(@NotNull Main plugin) {
+        this.plugin = plugin;
+        this.enumHandler = EnumHandler.getInstance();
+        this.config = ConfigHandler.getInstance();
+        this.offlinePlayerHandler = OfflinePlayerHandler.getInstance();
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "playerstats";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return String.join(", ", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return Objects.requireNonNullElse(plugin.getDescription().getVersion(), plugin.getDescription().getName());
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public @Nullable String onPlaceholderRequest(Player player, @NotNull String params) {
+        try {
+            PlaceholderArguments arguments = PlaceholderArguments.parse(params, player, enumHandler, offlinePlayerHandler);
+            return switch (arguments.target) {
+                case PLAYER -> handlePlayerPlaceholder(arguments);
+                case SERVER -> handleServerPlaceholder(arguments);
+                case TOP -> handleTopPlaceholder(arguments);
+            };
+        } catch (IllegalArgumentException exception) {
+            plugin.getLogger().log(Level.FINEST, "Failed to parse placeholder request: " + params, exception);
+            return "";
+        }
+    }
+
+    private @Nullable String handlePlayerPlaceholder(@NotNull PlaceholderArguments arguments) {
+        if (arguments.playerName == null) {
+            return "";
+        }
+
+        if (!arguments.allowExcluded && offlinePlayerHandler.isExcludedPlayer(arguments.playerName)) {
+            return "";
+        }
+
+        PlayerStatRequest request = arguments.worldName == null
+                ? new PlayerStatRequest(arguments.playerName)
+                : new PlayerStatRequest(arguments.playerName, arguments.worldName);
+
+        StatRequest<Integer> configuredRequest = configureRequest(request, arguments.statistic, arguments.subStatisticName);
+        if (configuredRequest == null || !configuredRequest.isValid()) {
+            return "";
+        }
+
+        StatResult<Integer> result = StatRequestManager.execute(configuredRequest);
+        if (arguments.formatted) {
+            return result.formattedString();
+        }
+        return String.valueOf(result.value());
+    }
+
+    private @Nullable String handleServerPlaceholder(@NotNull PlaceholderArguments arguments) {
+        ServerStatRequest request = arguments.worldName == null
+                ? new ServerStatRequest()
+                : new ServerStatRequest(arguments.worldName);
+
+        StatRequest<Long> configuredRequest = configureRequest(request, arguments.statistic, arguments.subStatisticName);
+        if (configuredRequest == null || !configuredRequest.isValid()) {
+            return "";
+        }
+
+        StatResult<Long> result = StatRequestManager.execute(configuredRequest);
+        if (arguments.formatted) {
+            return result.formattedString();
+        }
+        return String.valueOf(result.value());
+    }
+
+    private @Nullable String handleTopPlaceholder(@NotNull PlaceholderArguments arguments) {
+        int topSize = arguments.topListSize == null || arguments.topListSize <= 0
+                ? config.getTopListMaxSize()
+                : arguments.topListSize;
+
+        TopStatRequest request = arguments.worldName == null
+                ? new TopStatRequest(topSize)
+                : new TopStatRequest(topSize, arguments.worldName);
+
+        StatRequest<LinkedHashMap<String, Integer>> configuredRequest = configureRequest(request, arguments.statistic, arguments.subStatisticName);
+        if (configuredRequest == null || !configuredRequest.isValid()) {
+            return "";
+        }
+
+        StatResult<LinkedHashMap<String, Integer>> result = StatRequestManager.execute(configuredRequest);
+        LinkedHashMap<String, Integer> values = result.value();
+        if (values.isEmpty()) {
+            return "";
+        }
+
+        if (arguments.formatted && arguments.position == null && arguments.playerName == null) {
+            return result.formattedString();
+        }
+
+        if (arguments.playerName != null) {
+            return handleTopPlayer(arguments, values);
+        }
+
+        if (arguments.position != null) {
+            return handleTopPosition(arguments, values);
+        }
+
+        Map.Entry<String, Integer> firstEntry = values.entrySet().iterator().next();
+        if (arguments.returnValue) {
+            return String.valueOf(firstEntry.getValue());
+        }
+        if (arguments.formatted) {
+            return formatTopEntry(1, firstEntry.getKey(), firstEntry.getValue());
+        }
+        return firstEntry.getKey();
+    }
+
+    private @Nullable String handleTopPlayer(@NotNull PlaceholderArguments arguments, LinkedHashMap<String, Integer> values) {
+        int index = 1;
+        for (Map.Entry<String, Integer> entry : values.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(arguments.playerName)) {
+                if (arguments.returnRank) {
+                    return String.valueOf(index);
+                }
+                if (arguments.returnValue) {
+                    return String.valueOf(entry.getValue());
+                }
+                if (arguments.formatted) {
+                    return formatTopEntry(index, entry.getKey(), entry.getValue());
+                }
+                return entry.getKey();
+            }
+            index++;
+        }
+        return "";
+    }
+
+    private @Nullable String handleTopPosition(@NotNull PlaceholderArguments arguments, LinkedHashMap<String, Integer> values) {
+        if (arguments.position <= 0 || arguments.position > values.size()) {
+            return "";
+        }
+
+        Iterator<Map.Entry<String, Integer>> iterator = values.entrySet().iterator();
+        int counter = 1;
+        while (iterator.hasNext()) {
+            Map.Entry<String, Integer> entry = iterator.next();
+            if (counter == arguments.position) {
+                if (arguments.returnValue) {
+                    return String.valueOf(entry.getValue());
+                }
+                if (arguments.formatted) {
+                    return formatTopEntry(counter, entry.getKey(), entry.getValue());
+                }
+                return entry.getKey();
+            }
+            counter++;
+        }
+        return "";
+    }
+
+    private String formatTopEntry(int position, String playerName, int value) {
+        return position + ". " + playerName + " - " + value;
+    }
+
+    private <T> @Nullable StatRequest<T> configureRequest(@NotNull RequestGenerator<T> request,
+                                                          @NotNull Statistic statistic,
+                                                          @Nullable String subStatisticName) {
+        try {
+            return switch (statistic.getType()) {
+                case UNTYPED -> request.untyped(statistic);
+                case BLOCK -> {
+                    Material block = enumHandler.getBlockEnum(subStatisticName);
+                    yield block != null ? request.blockOrItemType(statistic, block) : null;
+                }
+                case ITEM -> {
+                    Material item = enumHandler.getItemEnum(subStatisticName);
+                    yield item != null ? request.blockOrItemType(statistic, item) : null;
+                }
+                case ENTITY -> {
+                    EntityType entity = enumHandler.getEntityEnum(subStatisticName);
+                    yield entity != null ? request.entityType(statistic, entity) : null;
+                }
+            };
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private enum PlaceholderTarget {
+        PLAYER, SERVER, TOP
+    }
+
+    private record PlaceholderArguments(PlaceholderTarget target,
+                                        Statistic statistic,
+                                        @Nullable String subStatisticName,
+                                        @Nullable String playerName,
+                                        @Nullable String worldName,
+                                        @Nullable Integer topListSize,
+                                        @Nullable Integer position,
+                                        boolean formatted,
+                                        boolean returnValue,
+                                        boolean returnRank,
+                                        boolean allowExcluded) {
+
+        private static final Set<String> KNOWN_FLAGS = Set.of("formatted", "format", "value", "raw", "rank");
+
+        private static PlaceholderArguments parse(String params,
+                                                   @Nullable Player player,
+                                                   @NotNull EnumHandler enumHandler,
+                                                   @NotNull OfflinePlayerHandler offlinePlayerHandler) {
+            String[] segments = OPTION_SPLIT_PATTERN.split(params);
+            if (segments.length < 2) {
+                throw new IllegalArgumentException("Placeholder needs at least a target and statistic");
+            }
+
+            PlaceholderTarget target = parseTarget(segments[0]);
+            Statistic statistic = parseStatistic(segments[1], enumHandler);
+
+            String subStat = null;
+            String requestedPlayer = null;
+            String worldName = null;
+            Integer topSize = null;
+            Integer position = null;
+            boolean formatted = false;
+            boolean returnValue = false;
+            boolean returnRank = false;
+            boolean allowExcluded = ConfigHandler.getInstance().allowPlayerLookupsForExcludedPlayers();
+
+            for (int i = 2; i < segments.length; i++) {
+                String segment = segments[i].trim();
+                if (segment.isEmpty()) {
+                    continue;
+                }
+
+                int equalsIndex = segment.indexOf('=');
+                if (equalsIndex > 0) {
+                    String key = segment.substring(0, equalsIndex).toLowerCase(Locale.ENGLISH);
+                    String value = segment.substring(equalsIndex + 1).trim();
+                    switch (key) {
+                        case "player" -> requestedPlayer = value;
+                        case "world" -> worldName = value;
+                        case "size", "top" -> topSize = tryParseInt(value);
+                        case "position", "pos", "rank" -> position = tryParseInt(value);
+                        case "allowexcluded" -> allowExcluded = Boolean.parseBoolean(value);
+                        default -> {
+                            if (subStat == null && !KNOWN_FLAGS.contains(segment.toLowerCase(Locale.ENGLISH))) {
+                                subStat = value;
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                String lowerSegment = segment.toLowerCase(Locale.ENGLISH);
+                if (lowerSegment.equals("formatted") || lowerSegment.equals("format")) {
+                    formatted = true;
+                    continue;
+                }
+                if (lowerSegment.equals("value") || lowerSegment.equals("raw")) {
+                    returnValue = true;
+                    continue;
+                }
+                if (lowerSegment.equals("rank")) {
+                    returnRank = true;
+                    continue;
+                }
+
+                if (subStat == null) {
+                    subStat = segment;
+                }
+            }
+
+            if (target == PlaceholderTarget.PLAYER && requestedPlayer == null) {
+                requestedPlayer = player != null ? player.getName() : null;
+            }
+
+            if (target == PlaceholderTarget.PLAYER && requestedPlayer != null &&
+                    !offlinePlayerHandler.isIncludedPlayer(requestedPlayer) && !allowExcluded) {
+                requestedPlayer = null;
+            }
+
+            return new PlaceholderArguments(target, statistic, subStat, requestedPlayer,
+                    worldName, topSize, position, formatted, returnValue, returnRank, allowExcluded);
+        }
+
+        private static PlaceholderTarget parseTarget(String segment) {
+            return switch (segment.toLowerCase(Locale.ENGLISH)) {
+                case "player", "p", "me" -> PlaceholderTarget.PLAYER;
+                case "server", "s" -> PlaceholderTarget.SERVER;
+                case "top", "t" -> PlaceholderTarget.TOP;
+                default -> throw new IllegalArgumentException("Unknown target: " + segment);
+            };
+        }
+
+        private static Statistic parseStatistic(String segment, EnumHandler enumHandler) {
+            Statistic statistic = enumHandler.getStatEnum(segment.trim());
+            if (statistic == null) {
+                throw new IllegalArgumentException("Unknown statistic: " + segment);
+            }
+            return statistic;
+        }
+
+        private static Integer tryParseInt(String value) {
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- embed a PlaceholderAPI expansion directly in the plugin and register it automatically when PlaceholderAPI is present
- implement flexible placeholder parsing that supports player, server and top lookups with optional formatting and filtering flags
- document the new built-in placeholders and usage examples in the README

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cb25fdfe008326a8b71b9903ec1ca9