### PR TITLE
Add operator-only command to reset per-world statistics

### DIFF
--- a/src/main/java/com/artemis/the/gr8/playerstats/core/Main.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/Main.java
@@ -29,8 +29,10 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public final class Main extends JavaPlugin implements PlayerStats {
 
@@ -181,6 +183,13 @@ public final class Main extends JavaPlugin implements PlayerStats {
         if (sharecmd != null) {
             sharecmd.setExecutor(new ShareCommand());
         }
+
+        PluginCommand statisticscmd = this.getCommand("statistics");
+        if (statisticscmd != null) {
+            StatisticsCommand statisticsCommand = new StatisticsCommand();
+            statisticscmd.setExecutor(statisticsCommand);
+            statisticscmd.setTabCompleter(statisticsCommand);
+        }
     }
 
     private void registerPlaceholderExpansion() {
@@ -252,5 +261,25 @@ public final class Main extends JavaPlugin implements PlayerStats {
     @Override
     public @NotNull StatNumberFormatter getStatNumberFormatter() {
         return new NumberFormatter();
+    }
+
+    public static boolean resetWorldStatistics(String worldName) {
+        boolean removed = worldStatsDb.resetWorld(worldName);
+        if (removed) {
+            try {
+                worldStatsSync.save();
+            } catch (IOException e) {
+                PluginLogger.log(LogLevel.WARNING, "Nie udało się zapisać world_stats.json po resecie świata " + worldName + ": " + e.getMessage());
+            }
+        }
+        return removed;
+    }
+
+    public static boolean hasWorldStatistics(String worldName) {
+        return worldStatsDb.hasWorld(worldName);
+    }
+
+    public static Set<String> getWorldsWithStatistics() {
+        return worldStatsDb.getRecordedWorlds();
     }
 }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/commands/StatisticsCommand.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/commands/StatisticsCommand.java
@@ -1,0 +1,142 @@
+package com.artemis.the.gr8.playerstats.core.commands;
+
+import com.artemis.the.gr8.playerstats.core.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public final class StatisticsCommand implements CommandExecutor, org.bukkit.command.TabCompleter {
+
+    private static final String RESET_SUBCOMMAND = "reset";
+    private static final String CONFIRM_ARGUMENT = "confirm";
+    private static final long CONFIRMATION_TIMEOUT = TimeUnit.MINUTES.toMillis(2);
+
+    private final Map<String, PendingReset> pendingConfirmations = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission("playerstats.statistics.reset")) {
+            sender.sendMessage(ChatColor.RED + "Nie masz uprawnień do użycia tej komendy.");
+            return true;
+        }
+
+        if (args.length < 2 || !RESET_SUBCOMMAND.equalsIgnoreCase(args[0])) {
+            sendUsage(sender, label);
+            return true;
+        }
+
+        String worldName = args[1];
+        String senderKey = getSenderKey(sender);
+        removeIfExpired(senderKey);
+
+        if (args.length == 2) {
+            if (!Main.hasWorldStatistics(worldName)) {
+                sender.sendMessage(ChatColor.YELLOW + "Brak zapisanych statystyk dla świata " + ChatColor.AQUA + worldName + ChatColor.YELLOW + ".");
+                return true;
+            }
+
+            pendingConfirmations.put(senderKey, new PendingReset(worldName));
+            sender.sendMessage(ChatColor.GOLD + "Potwierdź reset wpisując " + ChatColor.RED + "/" + label + " " + RESET_SUBCOMMAND + " " + worldName + " " + CONFIRM_ARGUMENT + ChatColor.GOLD + " w ciągu 2 minut.");
+            return true;
+        }
+
+        if (args.length >= 3 && CONFIRM_ARGUMENT.equalsIgnoreCase(args[2])) {
+            PendingReset pending = pendingConfirmations.get(senderKey);
+            if (pending == null || pending.isExpired() || !pending.worldName.equalsIgnoreCase(worldName)) {
+                sender.sendMessage(ChatColor.YELLOW + "Brak oczekującej operacji resetu dla świata " + ChatColor.AQUA + worldName + ChatColor.YELLOW + ".");
+                pendingConfirmations.remove(senderKey);
+                return true;
+            }
+
+            pendingConfirmations.remove(senderKey);
+            if (Main.resetWorldStatistics(pending.worldName)) {
+                sender.sendMessage(ChatColor.GREEN + "Statystyki dla świata " + ChatColor.AQUA + pending.worldName + ChatColor.GREEN + " zostały zresetowane.");
+            } else {
+                sender.sendMessage(ChatColor.YELLOW + "Nie znaleziono statystyk do resetu dla świata " + ChatColor.AQUA + pending.worldName + ChatColor.YELLOW + ".");
+            }
+            return true;
+        }
+
+        sendUsage(sender, label);
+        return true;
+    }
+
+    private void sendUsage(@NotNull CommandSender sender, @NotNull String label) {
+        sender.sendMessage(ChatColor.YELLOW + "Użycie: " + ChatColor.AQUA + "/" + label + " " + RESET_SUBCOMMAND + " <world> [" + CONFIRM_ARGUMENT + "]");
+    }
+
+    private void removeIfExpired(String senderKey) {
+        PendingReset pending = pendingConfirmations.get(senderKey);
+        if (pending != null && pending.isExpired()) {
+            pendingConfirmations.remove(senderKey);
+        }
+    }
+
+    private String getSenderKey(CommandSender sender) {
+        if (sender instanceof Player player) {
+            return player.getUniqueId().toString();
+        }
+        return sender.getName();
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (!sender.hasPermission("playerstats.statistics.reset")) {
+            return Collections.emptyList();
+        }
+
+        if (args.length == 1) {
+            return StringUtil.copyPartialMatches(args[0], List.of(RESET_SUBCOMMAND), new ArrayList<>());
+        }
+
+        if (args.length == 2 && RESET_SUBCOMMAND.equalsIgnoreCase(args[0])) {
+            return StringUtil.copyPartialMatches(args[1], getKnownWorlds(), new ArrayList<>());
+        }
+
+        if (args.length == 3 && RESET_SUBCOMMAND.equalsIgnoreCase(args[0])) {
+            return StringUtil.copyPartialMatches(args[2], List.of(CONFIRM_ARGUMENT), new ArrayList<>());
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<String> getKnownWorlds() {
+        Set<String> recorded = Main.getWorldsWithStatistics();
+        List<String> suggestions = new ArrayList<>(recorded);
+        for (World world : Bukkit.getWorlds()) {
+            if (!suggestions.contains(world.getName())) {
+                suggestions.add(world.getName());
+            }
+        }
+        return suggestions;
+    }
+
+    private static final class PendingReset {
+        private final String worldName;
+        private final long expiresAt;
+
+        private PendingReset(String worldName) {
+            this.worldName = worldName;
+            this.expiresAt = System.currentTimeMillis() + CONFIRMATION_TIMEOUT;
+        }
+
+        private boolean isExpired() {
+            return System.currentTimeMillis() > expiresAt;
+        }
+    }
+}

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/PlayerWorldStats.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/PlayerWorldStats.java
@@ -1,9 +1,11 @@
 package com.artemis.the.gr8.playerstats.core.storage;
 
 import org.bukkit.Statistic;
+
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Set;
 
 /**
  * Struktura danych do przechowywania statystyk per world dla gracza.
@@ -22,5 +24,17 @@ public class PlayerWorldStats {
 
     public Map<String, Map<Statistic, Integer>> getAllStats() {
         return worldStats;
+    }
+
+    public boolean clearWorld(String world) {
+        return worldStats.remove(world) != null;
+    }
+
+    public boolean hasWorld(String world) {
+        return worldStats.containsKey(world);
+    }
+
+    public Set<String> getRecordedWorlds() {
+        return new HashSet<>(worldStats.keySet());
     }
 }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/WorldStatsDatabase.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/WorldStatsDatabase.java
@@ -1,9 +1,11 @@
 package com.artemis.the.gr8.playerstats.core.storage;
 
-import com.artemis.the.gr8.playerstats.core.storage.PlayerWorldStats;
 import org.bukkit.Statistic;
+
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -27,5 +29,30 @@ public class WorldStatsDatabase {
 
     public Map<UUID, PlayerWorldStats> getAll() {
         return playerStats;
+    }
+
+    public boolean resetWorld(String world) {
+        boolean removedAny = false;
+        for (PlayerWorldStats stats : playerStats.values()) {
+            removedAny |= stats.clearWorld(world);
+        }
+        return removedAny;
+    }
+
+    public boolean hasWorld(String world) {
+        for (PlayerWorldStats stats : playerStats.values()) {
+            if (stats.hasWorld(world)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Set<String> getRecordedWorlds() {
+        Set<String> worlds = new HashSet<>();
+        for (PlayerWorldStats stats : playerStats.values()) {
+            worlds.addAll(stats.getRecordedWorlds());
+        }
+        return worlds;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -35,6 +35,11 @@ commands:
     usage: "§6/statexclude info"
     permission: playerstats.exclude
 
+  statistics:
+    description: Resetuje statystyki dla wskazanego świata
+    usage: "§6/statistics reset <world> [confirm]"
+    permission: playerstats.statistics.reset
+
 permissions:
   playerstats.stat:
     description: Allows usage of /statistic
@@ -47,4 +52,7 @@ permissions:
     default: op
   playerstats.reload:
     description: Allows usage of /statreload
+    default: op
+  playerstats.statistics.reset:
+    description: Allows resetting per-world statistics
     default: op


### PR DESCRIPTION
## Summary
- add a new /statistics command that allows operators to reset stored statistics for a specific world after confirmation
- extend per-world storage utilities with helpers to clear world entries and expose recorded world names
- register the new command and permission in plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4ca21d3c83268b9941c203c5a482