### PR TITLE
Adjust per-world stat tracking

### DIFF
--- a/src/main/java/com/artemis/the/gr8/playerstats/core/listeners/JoinListener.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/listeners/JoinListener.java
@@ -12,6 +12,9 @@ import org.bukkit.event.player.PlayerStatisticIncrementEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -23,9 +26,12 @@ public class JoinListener implements Listener {
     private final OfflinePlayerHandler offlinePlayerHandler;
     private final WorldStatsDatabase db;
 
+    private final Map<UUID, Map<Statistic, Integer>> trackedStatistics;
+
     public JoinListener() {
         offlinePlayerHandler = OfflinePlayerHandler.getInstance();
         db = Main.worldStatsDb; // zakładam, że masz to w Main jako singleton
+        trackedStatistics = new HashMap<>();
     }
 
     @EventHandler
@@ -35,7 +41,7 @@ public class JoinListener implements Listener {
             offlinePlayerHandler.addNewIncludedPlayer(player);
         }
 
-        // snapshot wszystkich statów na start
+        // zaktualizuj lokalny cache statystyk na start
         syncPlayerStats(player);
     }
 
@@ -46,15 +52,32 @@ public class JoinListener implements Listener {
         String world = player.getWorld().getName();
         Statistic stat = event.getStatistic();
 
-        if (stat.getType() == Statistic.Type.UNTYPED) {
-            int newValue = player.getStatistic(stat); // globalna wartość
-            db.setStat(uuid, world, stat, newValue);
+        if (stat.getType() != Statistic.Type.UNTYPED) {
+            return;
         }
+
+        int delta = event.getNewValue() - event.getPreviousValue();
+        if (delta <= 0) {
+            delta = deriveDeltaFromCache(uuid, stat, event.getNewValue());
+        }
+        if (delta <= 0) {
+            updateTrackedValue(uuid, stat, event.getNewValue());
+            return;
+        }
+
+        if (!db.hasWorld(world)) {
+            // świat został zresetowany – zacznij zbierać dane od nowa
+            resetTrackedStats(uuid);
+        }
+
+        int currentValue = db.getStat(uuid, world, stat);
+        db.setStat(uuid, world, stat, currentValue + delta);
+        updateTrackedValue(uuid, stat, event.getNewValue());
     }
 
     @EventHandler
     public void onWorldChange(PlayerChangedWorldEvent event) {
-        // przy zmianie świata zrób snapshot dla nowego świata
+        // przy zmianie świata zresetuj cache i przygotuj nowe wartości referencyjne
         Player player = event.getPlayer();
         syncPlayerStats(player);
     }
@@ -63,11 +86,41 @@ public class JoinListener implements Listener {
         UUID uuid = player.getUniqueId();
         String world = player.getWorld().getName();
 
+        if (!db.hasWorld(world)) {
+            // świeżo zresetowany świat – nie zapisuj nic do bazy, jedynie zresetuj cache
+            resetTrackedStats(uuid);
+            return;
+        }
+
+        Map<Statistic, Integer> snapshot = trackedStatistics.computeIfAbsent(uuid, key -> new EnumMap<>(Statistic.class));
+        snapshot.clear();
         for (Statistic stat : Statistic.values()) {
             if (stat.getType() == Statistic.Type.UNTYPED) {
-                int value = player.getStatistic(stat);
-                db.setStat(uuid, world, stat, value);
+                snapshot.put(stat, player.getStatistic(stat));
             }
         }
+    }
+
+    private void updateTrackedValue(UUID uuid, Statistic stat, int newValue) {
+        Map<Statistic, Integer> playerStats = trackedStatistics.computeIfAbsent(uuid, key -> new EnumMap<>(Statistic.class));
+        playerStats.put(stat, newValue);
+    }
+
+    private int deriveDeltaFromCache(UUID uuid, Statistic stat, int newValue) {
+        Map<Statistic, Integer> playerStats = trackedStatistics.get(uuid);
+        if (playerStats == null) {
+            return 0;
+        }
+
+        Integer previousValue = playerStats.get(stat);
+        if (previousValue == null) {
+            return 0;
+        }
+
+        return newValue - previousValue;
+    }
+
+    private void resetTrackedStats(UUID uuid) {
+        trackedStatistics.remove(uuid);
     }
 }


### PR DESCRIPTION
## Summary
- cache per-player statistic baselines instead of copying global Bukkit values into the per-world database
- derive per-world updates from PlayerStatisticIncrementEvent deltas and skip resync when the world has been reset

## Testing
- mvn -q -DskipTests package *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc62b4898c8326a32976b2ed901d86