### PR TITLE
Ensure MariaDB database exists before connecting

### DIFF
--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
@@ -105,7 +105,36 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
         properties.setProperty("user", settings.username());
         properties.setProperty("password", settings.password());
         properties.setProperty("useSSL", String.valueOf(settings.useSsl()));
-        String url = "jdbc:mariadb://" + settings.host() + ":" + settings.port() + "/" + settings.database();
+        String baseUrl = "jdbc:mariadb://" + settings.host() + ":" + settings.port() + "/";
+        Connection serverConnection = null;
+        try {
+            serverConnection = DriverManager.getConnection(baseUrl, properties);
+            serverConnection.setAutoCommit(false);
+            String databaseIdentifier = "`" + settings.database().replace("`", "") + "`";
+            String createDatabaseSql = "CREATE DATABASE IF NOT EXISTS " + databaseIdentifier;
+            try (Statement statement = serverConnection.createStatement()) {
+                statement.executeUpdate(createDatabaseSql);
+            }
+            serverConnection.commit();
+        } catch (SQLException ex) {
+            if (serverConnection != null) {
+                try {
+                    serverConnection.rollback();
+                } catch (SQLException rollbackEx) {
+                    PluginLogger.log(LogLevel.WARNING, "Failed to rollback MariaDB database creation transaction: " + rollbackEx.getMessage());
+                }
+            }
+            throw ex;
+        } finally {
+            if (serverConnection != null) {
+                try {
+                    serverConnection.close();
+                } catch (SQLException closeEx) {
+                    PluginLogger.log(LogLevel.WARNING, "Failed to close MariaDB server connection: " + closeEx.getMessage());
+                }
+            }
+        }
+        String url = baseUrl + settings.database();
         connection = DriverManager.getConnection(url, properties);
         connection.setAutoCommit(false);
     }


### PR DESCRIPTION
## Summary
- open a preliminary MariaDB connection without a database to ensure the configured database exists
- create the database if necessary with safe identifier quoting before opening the main connection
- preserve transaction handling, auto-commit settings, and logging while closing the temporary connection

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3cca992883268fd710f3b214923d