### PR TITLE
Ensure MariaDB driver loads before opening connections

### DIFF
--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
@@ -101,6 +101,12 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
     }
 
     private void openConnection() throws SQLException {
+        try {
+            Class.forName("org.mariadb.jdbc.Driver");
+        } catch (ClassNotFoundException ex) {
+            throw new SQLException("MariaDB driver not found on the classpath", ex);
+        }
+
         Properties properties = new Properties();
         properties.setProperty("user", settings.username());
         properties.setProperty("password", settings.password());


### PR DESCRIPTION
## Summary
- explicitly load the MariaDB JDBC driver before creating database connections so the plugin can locate the driver when META-INF services are missing

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cf43a8de008326be6dfb74f03d1e88