### PR TITLE
Add player name tracking across world stats backends

### DIFF
--- a/src/main/java/com/artemis/the/gr8/playerstats/core/listeners/JoinListener.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/listeners/JoinListener.java
@@ -40,6 +40,7 @@ public class JoinListener implements Listener {
             offlinePlayerHandler.addNewIncludedPlayer(player);
         }
 
+        updatePlayerName(player);
         // zaktualizuj lokalny cache statystyk na start
         syncPlayerStats(player);
     }
@@ -54,6 +55,8 @@ public class JoinListener implements Listener {
         if (stat.getType() != Statistic.Type.UNTYPED) {
             return;
         }
+
+        updatePlayerName(player);
 
         int delta = event.getNewValue() - event.getPreviousValue();
         if (delta <= 0) {
@@ -78,6 +81,7 @@ public class JoinListener implements Listener {
     public void onWorldChange(PlayerChangedWorldEvent event) {
         // przy zmianie świata zresetuj cache i przygotuj nowe wartości referencyjne
         Player player = event.getPlayer();
+        updatePlayerName(player);
         syncPlayerStats(player);
     }
 
@@ -121,5 +125,9 @@ public class JoinListener implements Listener {
 
     private void resetTrackedStats(UUID uuid) {
         trackedStatistics.remove(uuid);
+    }
+
+    private void updatePlayerName(Player player) {
+        db.setPlayerName(player.getUniqueId(), player.getName());
     }
 }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/FileWorldStatsStorage.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/FileWorldStatsStorage.java
@@ -53,10 +53,7 @@ public class FileWorldStatsStorage implements WorldStatsPersistence {
 
         try (Reader reader = new FileReader(file)) {
             Map<UUID, PlayerWorldStats> map = GSON.fromJson(reader, DB_TYPE);
-            database.getAll().clear();
-            if (map != null) {
-                database.getAll().putAll(map);
-            }
+            database.replaceAll(map);
         } catch (JsonSyntaxException ex) {
             throw new IOException("Invalid JSON in " + file.getAbsolutePath(), ex);
         }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
@@ -36,15 +36,17 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
     @Override
     public void load(WorldStatsDatabase database) throws Exception {
         ensureConnection();
-        String query = "SELECT player_uuid, world, statistic, value FROM " + tableIdentifier();
+        String query = "SELECT player_uuid, player_name, world, statistic, value FROM " + tableIdentifier();
         try (PreparedStatement statement = connection.prepareStatement(query);
              ResultSet resultSet = statement.executeQuery()) {
             while (resultSet.next()) {
                 try {
                     UUID uuid = UUID.fromString(resultSet.getString("player_uuid"));
+                    String playerName = resultSet.getString("player_name");
                     String world = resultSet.getString("world");
                     Statistic statistic = Statistic.valueOf(resultSet.getString("statistic"));
                     int value = resultSet.getInt("value");
+                    database.setPlayerName(uuid, playerName);
                     database.setStat(uuid, world, statistic, value);
                 } catch (IllegalArgumentException ex) {
                     PluginLogger.logWarning("Skipping invalid statistic entry retrieved from MariaDB: " + ex.getMessage());
@@ -58,7 +60,7 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
         ensureConnection();
         String deleteSql = "DELETE FROM " + tableIdentifier();
         String insertSql = "INSERT INTO " + tableIdentifier() +
-                " (player_uuid, world, statistic, value) VALUES (?, ?, ?, ?)";
+                " (player_uuid, player_name, world, statistic, value) VALUES (?, ?, ?, ?, ?)";
         try (Statement deleteStatement = connection.createStatement();
              PreparedStatement insertStatement = connection.prepareStatement(insertSql)) {
             deleteStatement.executeUpdate(deleteSql);
@@ -66,13 +68,15 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
             for (Map.Entry<UUID, PlayerWorldStats> entry : database.getAll().entrySet()) {
                 UUID uuid = entry.getKey();
                 PlayerWorldStats stats = entry.getValue();
+                String playerName = stats.getPlayerName();
                 for (Map.Entry<String, Map<Statistic, Integer>> worldEntry : stats.getAllStats().entrySet()) {
                     String world = worldEntry.getKey();
                     for (Map.Entry<Statistic, Integer> statEntry : worldEntry.getValue().entrySet()) {
                         insertStatement.setString(1, uuid.toString());
-                        insertStatement.setString(2, world);
-                        insertStatement.setString(3, statEntry.getKey().name());
-                        insertStatement.setInt(4, statEntry.getValue());
+                        insertStatement.setString(2, playerName);
+                        insertStatement.setString(3, world);
+                        insertStatement.setString(4, statEntry.getKey().name());
+                        insertStatement.setInt(5, statEntry.getValue());
                         insertStatement.addBatch();
                     }
                 }
@@ -155,6 +159,7 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
     private void createTableIfNeeded() throws SQLException {
         String sql = "CREATE TABLE IF NOT EXISTS " + tableIdentifier() + " (" +
                 "player_uuid CHAR(36) NOT NULL," +
+                " player_name VARCHAR(255) NOT NULL DEFAULT ''," +
                 " world VARCHAR(255) NOT NULL," +
                 " statistic VARCHAR(64) NOT NULL," +
                 " value INT NOT NULL," +
@@ -163,9 +168,57 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
             statement.executeUpdate(sql);
             connection.commit();
         }
+        ensurePlayerNameColumnExists();
     }
 
     private String tableIdentifier() {
         return "`" + settings.table().replace("`", "") + "`";
+    }
+
+    private void ensurePlayerNameColumnExists() throws SQLException {
+        String checkSql = "SELECT COUNT(*) FROM information_schema.COLUMNS " +
+                "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = 'player_name'";
+        String databaseName = sanitizedIdentifier(settings.database());
+        String tableName = sanitizedIdentifier(settings.table());
+        boolean hasColumn = false;
+        try (PreparedStatement checkStatement = connection.prepareStatement(checkSql)) {
+            checkStatement.setString(1, databaseName);
+            checkStatement.setString(2, tableName);
+            try (ResultSet resultSet = checkStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    hasColumn = resultSet.getInt(1) > 0;
+                }
+            }
+        }
+
+        if (!hasColumn) {
+            String alterSql = "ALTER TABLE " + tableIdentifier() +
+                    " ADD COLUMN player_name VARCHAR(255) NOT NULL DEFAULT '' AFTER player_uuid";
+            try (Statement alterStatement = connection.createStatement()) {
+                alterStatement.executeUpdate(alterSql);
+            }
+            connection.commit();
+        }
+
+        enforcePlayerNameColumnDefaults();
+    }
+
+    private void enforcePlayerNameColumnDefaults() throws SQLException {
+        String modifySql = "ALTER TABLE " + tableIdentifier() +
+                " MODIFY COLUMN player_name VARCHAR(255) NOT NULL DEFAULT ''";
+        try (Statement modifyStatement = connection.createStatement()) {
+            modifyStatement.executeUpdate(modifySql);
+        }
+
+        String updateSql = "UPDATE " + tableIdentifier() +
+                " SET player_name = '' WHERE player_name IS NULL";
+        try (Statement updateStatement = connection.createStatement()) {
+            updateStatement.executeUpdate(updateSql);
+        }
+        connection.commit();
+    }
+
+    private String sanitizedIdentifier(String identifier) {
+        return identifier.replace("`", "");
     }
 }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/PlayerWorldStats.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/PlayerWorldStats.java
@@ -1,5 +1,6 @@
 package com.artemis.the.gr8.playerstats.core.storage;
 
+import com.google.gson.annotations.SerializedName;
 import org.bukkit.Statistic;
 
 import java.util.HashMap;
@@ -14,6 +15,9 @@ public class PlayerWorldStats {
     // Mapowanie: nazwa świata -> (statystyka -> wartość)
     private final Map<String, Map<Statistic, Integer>> worldStats = new HashMap<>();
 
+    @SerializedName("playerName")
+    private String playerName = "";
+
     public void setStat(String world, Statistic stat, int value) {
         worldStats.computeIfAbsent(world, k -> new HashMap<>()).put(stat, value);
     }
@@ -24,6 +28,14 @@ public class PlayerWorldStats {
 
     public Map<String, Map<Statistic, Integer>> getAllStats() {
         return worldStats;
+    }
+
+    public String getPlayerName() {
+        return playerName != null ? playerName : "";
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName != null ? playerName : "";
     }
 
     public boolean clearWorld(String world) {

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/WorldStatsDatabase.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/WorldStatsDatabase.java
@@ -16,7 +16,15 @@ public class WorldStatsDatabase {
     private final Map<UUID, PlayerWorldStats> playerStats = new HashMap<>();
 
     public PlayerWorldStats getOrCreatePlayerStats(UUID uuid) {
-        return playerStats.computeIfAbsent(uuid, k -> new PlayerWorldStats());
+        return getOrCreatePlayerStats(uuid, null);
+    }
+
+    public PlayerWorldStats getOrCreatePlayerStats(UUID uuid, String playerName) {
+        PlayerWorldStats stats = playerStats.computeIfAbsent(uuid, k -> new PlayerWorldStats());
+        if (playerName != null && !playerName.isEmpty()) {
+            stats.setPlayerName(playerName);
+        }
+        return stats;
     }
 
     public void setStat(UUID uuid, String world, Statistic stat, int value) {
@@ -25,6 +33,51 @@ public class WorldStatsDatabase {
 
     public int getStat(UUID uuid, String world, Statistic stat) {
         return getOrCreatePlayerStats(uuid).getStat(world, stat);
+    }
+
+    public void setPlayerName(UUID uuid, String playerName) {
+        getOrCreatePlayerStats(uuid).setPlayerName(playerName);
+    }
+
+    public String getPlayerName(UUID uuid) {
+        return getOrCreatePlayerStats(uuid).getPlayerName();
+    }
+
+    public void mergePlayerStats(UUID uuid, PlayerWorldStats stats) {
+        if (stats == null) {
+            return;
+        }
+
+        PlayerWorldStats existing = playerStats.computeIfAbsent(uuid, k -> new PlayerWorldStats());
+        String incomingName = stats.getPlayerName();
+        if (!incomingName.isEmpty() || existing.getPlayerName().isEmpty()) {
+            existing.setPlayerName(incomingName);
+        }
+
+        for (Map.Entry<String, Map<Statistic, Integer>> entry : stats.getAllStats().entrySet()) {
+            Map<Statistic, Integer> targetWorldStats = existing.getAllStats()
+                    .computeIfAbsent(entry.getKey(), key -> new HashMap<>());
+            Map<Statistic, Integer> incomingWorldStats = entry.getValue();
+            if (targetWorldStats == incomingWorldStats) {
+                continue;
+            }
+            targetWorldStats.clear();
+            targetWorldStats.putAll(incomingWorldStats);
+        }
+    }
+
+    public void replaceAll(Map<UUID, PlayerWorldStats> newData) {
+        playerStats.clear();
+        if (newData == null) {
+            return;
+        }
+        for (Map.Entry<UUID, PlayerWorldStats> entry : newData.entrySet()) {
+            UUID uuid = entry.getKey();
+            PlayerWorldStats stats = entry.getValue();
+            if (uuid != null && stats != null) {
+                mergePlayerStats(uuid, stats);
+            }
+        }
     }
 
     public Map<UUID, PlayerWorldStats> getAll() {


### PR DESCRIPTION
## Summary
- add a persisted `playerName` field to `PlayerWorldStats` together with accessors in `WorldStatsDatabase`
- update the join listener to refresh player names before writing any world statistics
- extend the file and MariaDB storage backends to read/write player names and migrate existing data

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cffed67d988326a735f6eaed7c5eed