### PR TITLE
Handle empty player names from MariaDB load

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>3.3.3</version>
@@ -296,6 +303,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
@@ -46,13 +46,20 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
                     String world = resultSet.getString("world");
                     Statistic statistic = Statistic.valueOf(resultSet.getString("statistic"));
                     int value = resultSet.getInt("value");
-                    database.setPlayerName(uuid, playerName);
-                    database.setStat(uuid, world, statistic, value);
+                    applyLoadedStat(database, uuid, playerName, world, statistic, value);
                 } catch (IllegalArgumentException ex) {
                     PluginLogger.logWarning("Skipping invalid statistic entry retrieved from MariaDB: " + ex.getMessage());
                 }
             }
         }
+    }
+
+    void applyLoadedStat(WorldStatsDatabase database, UUID uuid, String playerName,
+                         String world, Statistic statistic, int value) {
+        if (playerName != null && !playerName.isEmpty()) {
+            database.setPlayerName(uuid, playerName);
+        }
+        database.setStat(uuid, world, statistic, value);
     }
 
     @Override

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/WorldStatsDatabase.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/WorldStatsDatabase.java
@@ -36,7 +36,11 @@ public class WorldStatsDatabase {
     }
 
     public void setPlayerName(UUID uuid, String playerName) {
-        getOrCreatePlayerStats(uuid).setPlayerName(playerName);
+        PlayerWorldStats stats = getOrCreatePlayerStats(uuid);
+        String incomingName = playerName != null ? playerName : "";
+        if (!incomingName.isEmpty() || stats.getPlayerName().isEmpty()) {
+            stats.setPlayerName(incomingName);
+        }
     }
 
     public String getPlayerName(UUID uuid) {

--- a/src/test/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorageTest.java
+++ b/src/test/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorageTest.java
@@ -1,0 +1,42 @@
+package com.artemis.the.gr8.playerstats.core.storage;
+
+import com.artemis.the.gr8.playerstats.core.config.ConfigHandler;
+import org.bukkit.Statistic;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MariaDbWorldStatsStorageTest {
+
+    private WorldStatsDatabase database;
+    private MariaDbWorldStatsStorage storage;
+    private UUID playerUuid;
+
+    @BeforeEach
+    void setUp() {
+        database = new WorldStatsDatabase();
+        storage = new MariaDbWorldStatsStorage(new ConfigHandler.MariaDbSettings(
+                "localhost", 3306, "playerstats", "playerstats",
+                "change-me", "playerstats_world_stats", true));
+        playerUuid = UUID.randomUUID();
+    }
+
+    @Test
+    void loadDoesNotOverwriteKnownPlayerNameWithEmptyValue() {
+        database.setPlayerName(playerUuid, "KnownPlayer");
+
+        storage.applyLoadedStat(database, playerUuid, "", "world", Statistic.DEATHS, 5);
+
+        assertEquals("KnownPlayer", database.getPlayerName(playerUuid));
+    }
+
+    @Test
+    void loadAppliesNewNameWhenUnknown() {
+        storage.applyLoadedStat(database, playerUuid, "FreshName", "world", Statistic.JUMP, 3);
+
+        assertEquals("FreshName", database.getPlayerName(playerUuid));
+    }
+}


### PR DESCRIPTION
## Summary
- guard WorldStatsDatabase#setPlayerName so empty values do not overwrite known names
- ensure MariaDbWorldStatsStorage skips blank player_name values when loading rows
- add JUnit coverage for loading stats and configure Maven for JUnit 5

## Testing
- `mvn test` *(fails: unable to download Maven plugins in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0466f74f8832698cbba68cdcb19ea