### PR TITLE
Handle missing names when syncing MariaDB stats

### DIFF
--- a/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorage.java
@@ -1,8 +1,11 @@
 package com.artemis.the.gr8.playerstats.core.storage;
 
 import com.artemis.the.gr8.playerstats.core.config.ConfigHandler;
+import com.artemis.the.gr8.playerstats.core.utils.OfflinePlayerHandler;
 import com.artemis.the.gr8.playerstats.core.utils.PluginLogger;
 import com.artemis.the.gr8.playerstats.core.utils.PluginLogger.LogLevel;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
 
 import java.sql.Connection;
@@ -56,8 +59,11 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
 
     void applyLoadedStat(WorldStatsDatabase database, UUID uuid, String playerName,
                          String world, Statistic statistic, int value) {
+        PlayerWorldStats stats = database.getOrCreatePlayerStats(uuid);
         if (playerName != null && !playerName.isEmpty()) {
             database.setPlayerName(uuid, playerName);
+        } else {
+            cacheResolvedPlayerName(database, uuid, stats, "loading data from MariaDB");
         }
         database.setStat(uuid, world, statistic, value);
     }
@@ -76,6 +82,9 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
                 UUID uuid = entry.getKey();
                 PlayerWorldStats stats = entry.getValue();
                 String playerName = stats.getPlayerName();
+                if (playerName == null || playerName.isEmpty()) {
+                    playerName = cacheResolvedPlayerName(database, uuid, stats, "saving data to MariaDB");
+                }
                 for (Map.Entry<String, Map<Statistic, Integer>> worldEntry : stats.getAllStats().entrySet()) {
                     String world = worldEntry.getKey();
                     for (Map.Entry<Statistic, Integer> statEntry : worldEntry.getValue().entrySet()) {
@@ -108,6 +117,95 @@ public class MariaDbWorldStatsStorage implements WorldStatsPersistence {
             } finally {
                 connection = null;
             }
+        }
+    }
+
+    String cacheResolvedPlayerName(WorldStatsDatabase database, UUID uuid, PlayerWorldStats stats, String context) {
+        if (stats == null) {
+            stats = database.getOrCreatePlayerStats(uuid);
+        }
+
+        String cachedName = stats.getPlayerName();
+        if (cachedName != null && !cachedName.isEmpty()) {
+            return cachedName;
+        }
+
+        String resolvedName = resolvePlayerName(uuid);
+        if (!resolvedName.isEmpty()) {
+            stats.setPlayerName(resolvedName);
+            database.setPlayerName(uuid, resolvedName);
+            return resolvedName;
+        }
+
+        logWarningSafe("Unable to resolve player name for UUID " + uuid + " while " + context + ".");
+        return "";
+    }
+
+    protected String resolvePlayerName(UUID uuid) {
+        if (uuid == null) {
+            return "";
+        }
+
+        String bukkitName = resolveNameWithBukkit(uuid);
+        if (!bukkitName.isEmpty()) {
+            return bukkitName;
+        }
+
+        OfflinePlayerHandler handler = OfflinePlayerHandler.getExistingInstance();
+        if (handler == null && isBukkitAvailable()) {
+            handler = OfflinePlayerHandler.getInstance();
+        }
+
+        if (handler != null) {
+            String handlerName = handler.getKnownName(uuid);
+            if (handlerName != null && !handlerName.isEmpty()) {
+                return handlerName;
+            }
+        }
+
+        return "";
+    }
+
+    private boolean isBukkitAvailable() {
+        try {
+            return Bukkit.getServer() != null;
+        } catch (UnsupportedOperationException ex) {
+            return false;
+        }
+    }
+
+    private String resolveNameWithBukkit(UUID uuid) {
+        if (!isBukkitAvailable()) {
+            return "";
+        }
+
+        try {
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+            if (offlinePlayer != null) {
+                String name = offlinePlayer.getName();
+                if (name != null && !name.isEmpty()) {
+                    return name;
+                }
+            }
+        } catch (Exception ex) {
+            logDebugSafe("Failed to resolve player name via Bukkit for UUID " + uuid + ": " + ex.getMessage());
+        }
+        return "";
+    }
+
+    private void logWarningSafe(String message) {
+        try {
+            PluginLogger.logWarning(message);
+        } catch (IllegalStateException ignored) {
+            // PluginLogger not initialized during unit tests
+        }
+    }
+
+    private void logDebugSafe(String message) {
+        try {
+            PluginLogger.log(LogLevel.DEBUG, message);
+        } catch (IllegalStateException ignored) {
+            // PluginLogger not initialized during unit tests
         }
     }
 

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/utils/OfflinePlayerHandler.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/utils/OfflinePlayerHandler.java
@@ -8,6 +8,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -48,6 +49,10 @@ public final class OfflinePlayerHandler extends YamlFileHandler {
         }
     }
 
+    public static @Nullable OfflinePlayerHandler getExistingInstance() {
+        return instance;
+    }
+
     @Override
     public void reload() {
         super.reload();
@@ -71,6 +76,26 @@ public final class OfflinePlayerHandler extends YamlFileHandler {
 
     public boolean isExcludedPlayer(UUID uniqueID) {
         return excludedPlayerUUIDs.containsValue(uniqueID);
+    }
+
+    public @Nullable String getKnownName(@NotNull UUID uniqueID) {
+        String name = findPlayerName(includedPlayerUUIDs, uniqueID);
+        if (name != null) {
+            return name;
+        }
+        return findPlayerName(excludedPlayerUUIDs, uniqueID);
+    }
+
+    private @Nullable String findPlayerName(ConcurrentHashMap<String, UUID> map, UUID uniqueID) {
+        if (map == null || map.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<String, UUID> entry : map.entrySet()) {
+            if (uniqueID.equals(entry.getValue())) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 
     public boolean addPlayerToExcludeList(String playerName) {

--- a/src/test/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorageTest.java
+++ b/src/test/java/com/artemis/the/gr8/playerstats/core/storage/MariaDbWorldStatsStorageTest.java
@@ -39,4 +39,42 @@ class MariaDbWorldStatsStorageTest {
 
         assertEquals("FreshName", database.getPlayerName(playerUuid));
     }
+
+    @Test
+    void loadResolvesEmptyNameWhenResolverFindsValue() {
+        MariaDbWorldStatsStorage resolvingStorage = new TestMariaDbWorldStatsStorage("RecoveredName");
+
+        resolvingStorage.applyLoadedStat(database, playerUuid, "", "world", Statistic.WALK_ONE_CM, 42);
+
+        assertEquals("RecoveredName", database.getPlayerName(playerUuid));
+    }
+
+    @Test
+    void cacheResolvedPlayerNameUpdatesStats() {
+        MariaDbWorldStatsStorage resolvingStorage = new TestMariaDbWorldStatsStorage("ResolvedOnSave");
+        PlayerWorldStats stats = database.getOrCreatePlayerStats(playerUuid);
+
+        String resolved = resolvingStorage.cacheResolvedPlayerName(database, playerUuid, stats, "testing");
+
+        assertEquals("ResolvedOnSave", resolved);
+        assertEquals("ResolvedOnSave", stats.getPlayerName());
+        assertEquals("ResolvedOnSave", database.getPlayerName(playerUuid));
+    }
+
+    private static class TestMariaDbWorldStatsStorage extends MariaDbWorldStatsStorage {
+
+        private final String nameToReturn;
+
+        private TestMariaDbWorldStatsStorage(String nameToReturn) {
+            super(new ConfigHandler.MariaDbSettings(
+                    "localhost", 3306, "playerstats", "playerstats",
+                    "change-me", "playerstats_world_stats", true));
+            this.nameToReturn = nameToReturn;
+        }
+
+        @Override
+        protected String resolvePlayerName(UUID uuid) {
+            return nameToReturn;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- resolve missing player names while loading and saving MariaDB stats, updating the in-memory cache and logging unresolved UUIDs
- extend OfflinePlayerHandler to expose cached-name lookups without forcing initialization
- cover the new resolution behavior with unit tests

## Testing
- `mvn -q -DskipTests=false test` *(fails: network is unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d04f8ae7548326abef11985d8111e8